### PR TITLE
Add basic cli invocation for converter

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -21,9 +21,11 @@ runtime = "deno"
 allow_read = ["test", "gleam.toml"]
 
 [dependencies]
+argv = "~> 1.0"
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-javascript_dom_parser = ">= 1.0.0 and < 2.0.0"
 glam = ">= 2.0.0 and < 3.0.0"
+javascript_dom_parser = ">= 1.0.0 and < 2.0.0"
+simplifile = "~> 1.7"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -23,7 +23,9 @@ packages = [
 ]
 
 [requirements]
-glam = { version = ">= 2.0.0 and < 3.0.0"}
+argv = { version = "~> 1.0" }
+glam = { version = ">= 2.0.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 javascript_dom_parser = { version = ">= 1.0.0 and < 2.0.0" }
+simplifile = { version = "~> 1.7"}

--- a/src/html_lustre_converter/cli.gleam
+++ b/src/html_lustre_converter/cli.gleam
@@ -1,0 +1,20 @@
+//// Provide a basic commandline interface for the conversion which
+//// reads a file and prints the result to standard out
+
+import argv
+import gleam/io
+import html_lustre_converter
+import javascript_dom_parser/deno_polyfill
+import simplifile
+
+pub fn main() {
+  deno_polyfill.install_polyfill()
+
+  case argv.load().arguments {
+    [filename] -> {
+      let assert Ok(contents) = simplifile.read(filename)
+      io.println(html_lustre_converter.convert(contents))
+    }
+    _ -> io.println("Usage: html_lustre_converter <FILENAME>")
+  }
+}


### PR DESCRIPTION
So that we can run:

  gleam run -m html_lustre_converter/cli --target javascript --runtime deno -- file.html

And have the gleam code printed to standard out.

I am not familiar with the ins and outs of the best way to achieve this. It might be valid to work with stdin (or at least support it with a '-') rather than rely on a file. There might also be issues with the new dependencies as the final plan to have a web interface for the project.

I've not written a lot of gleam so happy to have feedback for anything that could/should be improved.