### PR TITLE
Properly support SVGs

### DIFF
--- a/app/src/app.gleam
+++ b/app/src/app.gleam
@@ -1,11 +1,10 @@
 import gleam/javascript/promise
 import html_lustre_converter
 import lustre
-import lustre/attribute.{attribute}
+import lustre/attribute
 import lustre/effect.{type Effect}
 import lustre/element.{type Element}
 import lustre/element/html
-import lustre/element/svg
 import lustre/event
 import plinth/browser/clipboard
 import plinth/javascript/global
@@ -20,9 +19,9 @@ pub type Model {
   Model(rendered_lustre: String, copy_button_text: String)
 }
 
-const copy_button_default_text = "Copy"
+const copy_button_default_text = "Copy 🧟"
 
-const copy_button_copied_text = "Copied"
+const copy_button_copied_text = "Copied 🥰"
 
 fn init(_flags) -> #(Model, Effect(e)) {
   let model =
@@ -97,13 +96,10 @@ fn view(model: Model) -> Element(Msg) {
           [
             event.on_click(UserClickedCopy),
             attribute.class(
-              "flex items-center gap-2 absolute bottom-3 right-3 bg-[#ffaff3] py-2 px-3 rounded-md font-bold transition-opacity hover:opacity-75",
+              "absolute bottom-3 right-3 bg-[#ffaff3] py-2 px-3 rounded-md font-bold transition-opacity hover:opacity-75",
             ),
           ],
-          [
-            lucide_copy_icon(),
-            element.text(model.copy_button_text)
-          ],
+          [element.text(model.copy_button_text)],
         ),
       ],
     ),
@@ -125,32 +121,4 @@ fn set_timeout(delay: Int, callback: fn() -> anything) -> Nil {
     Nil
   }
   global.set_timeout(callback, delay)
-}
-
-fn lucide_copy_icon() -> Element(a) {
-    svg.svg(
-      [
-        attribute.class("w-5 h-5"),
-        attribute("stroke-linejoin", "round"),
-        attribute("stroke-linecap", "round"),
-        attribute("stroke-width", "2.5"),
-        attribute("stroke", "currentColor"),
-        attribute("fill", "none"),
-        attribute("viewBox", "0 0 24 24"),
-        attribute("xmlns", "http://www.w3.org/2000/svg"),
-      ],
-      [
-        svg.rect([
-          attribute("ry", "2"),
-          attribute("rx", "2"),
-          attribute("y", "8"),
-          attribute("x", "8"),
-          attribute("height", "14"),
-          attribute("width", "14"),
-        ]),
-        svg.path([
-          attribute("d", "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"),
-        ]),
-      ],
-    )
 }

--- a/app/src/app.gleam
+++ b/app/src/app.gleam
@@ -1,10 +1,11 @@
 import gleam/javascript/promise
 import html_lustre_converter
 import lustre
-import lustre/attribute
+import lustre/attribute.{attribute}
 import lustre/effect.{type Effect}
 import lustre/element.{type Element}
 import lustre/element/html
+import lustre/element/svg
 import lustre/event
 import plinth/browser/clipboard
 import plinth/javascript/global
@@ -19,9 +20,9 @@ pub type Model {
   Model(rendered_lustre: String, copy_button_text: String)
 }
 
-const copy_button_default_text = "Copy 🧟"
+const copy_button_default_text = "Copy"
 
-const copy_button_copied_text = "Copied 🥰"
+const copy_button_copied_text = "Copied"
 
 fn init(_flags) -> #(Model, Effect(e)) {
   let model =
@@ -96,10 +97,13 @@ fn view(model: Model) -> Element(Msg) {
           [
             event.on_click(UserClickedCopy),
             attribute.class(
-              "absolute bottom-3 right-3 bg-[#ffaff3] py-2 px-3 rounded-md font-bold transition-opacity hover:opacity-75",
+              "flex items-center gap-2 absolute bottom-3 right-3 bg-[#ffaff3] py-2 px-3 rounded-md font-bold transition-opacity hover:opacity-75",
             ),
           ],
-          [element.text(model.copy_button_text)],
+          [
+            lucide_copy_icon(),
+            element.text(model.copy_button_text)
+          ],
         ),
       ],
     ),
@@ -121,4 +125,32 @@ fn set_timeout(delay: Int, callback: fn() -> anything) -> Nil {
     Nil
   }
   global.set_timeout(callback, delay)
+}
+
+fn lucide_copy_icon() -> Element(a) {
+    svg.svg(
+      [
+        attribute.class("w-5 h-5"),
+        attribute("stroke-linejoin", "round"),
+        attribute("stroke-linecap", "round"),
+        attribute("stroke-width", "2.5"),
+        attribute("stroke", "currentColor"),
+        attribute("fill", "none"),
+        attribute("viewBox", "0 0 24 24"),
+        attribute("xmlns", "http://www.w3.org/2000/svg"),
+      ],
+      [
+        svg.rect([
+          attribute("ry", "2"),
+          attribute("rx", "2"),
+          attribute("y", "8"),
+          attribute("x", "8"),
+          attribute("height", "14"),
+          attribute("width", "14"),
+        ]),
+        svg.path([
+          attribute("d", "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"),
+        ]),
+      ],
+    )
 }

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,6 +17,7 @@ allow_read = ["test", "gleam.toml"]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 javascript_dom_parser = ">= 1.0.0 and < 2.0.0"
 glam = ">= 2.0.0 and < 3.0.0"
+justin = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -23,7 +23,8 @@ packages = [
 ]
 
 [requirements]
-glam = { version = ">= 2.0.0 and < 3.0.0"}
+glam = { version = ">= 2.0.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 javascript_dom_parser = { version = ">= 1.0.0 and < 2.0.0" }
+justin = { version = ">= 1.0.1 and < 2.0.0"}

--- a/src/html_lustre_converter.gleam
+++ b/src/html_lustre_converter.gleam
@@ -407,6 +407,9 @@ fn print_attribute(attribute: #(String, String), is_svg: Bool) -> Document {
       )
     }
 
+    "viewbox" ->
+        doc.from_string("attribute(\"viewBox\", " <> print_string(attribute.1) <> ")")
+
     "type" ->
       doc.from_string("attribute.type_(" <> print_string(attribute.1) <> ")")
 

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -199,3 +199,27 @@ pub fn pre_whitespace_test() {
 )",
   )
 }
+
+pub fn svg_test() {
+    "<div>
+        <svg width=\"10\" height=\"10\" viewBox=\"0 0 10\">
+            <rect width=\"8\" height=\"8\" />
+        </svg>
+    </div>"
+    |> html_lustre_converter.convert
+    |> should.equal(
+        "html.div(
+  [],
+  [
+    svg.svg(
+      [
+        attribute(\"viewBox\", \"0 0 10\"),
+        attribute(\"height\", \"10\"),
+        attribute(\"width\", \"10\"),
+      ],
+      [svg.rect([attribute(\"height\", \"8\"), attribute(\"width\", \"8\")])],
+    ),
+  ],
+)"
+    )
+}

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -201,14 +201,14 @@ pub fn pre_whitespace_test() {
 }
 
 pub fn svg_test() {
-    "<div>
+  "<div>
         <svg width=\"10\" height=\"10\" viewBox=\"0 0 10\">
             <rect width=\"8\" height=\"8\" />
         </svg>
     </div>"
-    |> html_lustre_converter.convert
-    |> should.equal(
-        "html.div(
+  |> html_lustre_converter.convert
+  |> should.equal(
+    "html.div(
   [],
   [
     svg.svg(
@@ -220,6 +220,6 @@ pub fn svg_test() {
       [svg.rect([attribute(\"height\", \"8\"), attribute(\"width\", \"8\")])],
     ),
   ],
-)"
-    )
+)",
+  )
 }


### PR DESCRIPTION
This is a pretty simple, rudimentary addition to properly support Lustre SVG elements. There will inevitably be edge cases in the SVG spec I haven't considered, but for 99% of SVGs used on the web, this should work just fine, and be a nice helpful tool for people.

I added a couple of functions which pass an "is_svg" boolean down the chain, as it's helpful to consider context for elements, and considered a couple of edge cases in the attribute printer (eg, svg can't set the width with attribute.width, viewBox is case sensitive). There is one new test which covers both these cases, proving it works :)