### PR TITLE
Use svg mode for svg and it's children

### DIFF
--- a/src/html_lustre_converter.gleam
+++ b/src/html_lustre_converter.gleam
@@ -147,6 +147,7 @@ fn print_svg_element(
     | "pattern"
     | "switch"
     | "symbol"
+    | "svg"
     | // Descriptive elements
       "desc"
     | "metadata"


### PR DESCRIPTION
Fixes #11

This fixes my issue. Also causes `<svg>` to be converted to `svg.svg`, instead of previous `html.svg`. Both seem to work, so I don't think it's a problem.
However, `<button>` (and others) inside of `<svg>` will be converted to `element("button",...)`. I think this also isn't a problem because 1) I think it's not valid html and 2) lustre should render it the same way as `html.button` (or at least I think so)

Let me know if you want any changes (or make them yourself if it's easier for you, I allowed edits by maintainers)

Cheers