### PR TITLE
Fully qualify all Lustre functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The generated code now uses the `html.text` function fully qualified.
+
 ## v1.1.0 - 2024-07-16
 
 - SVGs are now supported.

--- a/src/html_lustre_converter.gleam
+++ b/src/html_lustre_converter.gleam
@@ -18,7 +18,7 @@ import javascript_dom_parser.{type HtmlNode, Comment, Element, Text} as parser
 /// ```gleam
 /// import lustre/element.{element, text, svg}
 /// ```
-/// 
+///
 /// If you are only using SVGs, that's all you need to import
 /// ```gleam
 /// import lustre/element/svg
@@ -60,7 +60,7 @@ fn strip_body_wrapper(html: HtmlNode, source: String) -> List(HtmlNode) {
 }
 
 fn print_text(t: String) -> Document {
-  doc.from_string("text(" <> print_string(t) <> ")")
+  doc.from_string("html.text(" <> print_string(t) <> ")")
 }
 
 fn print_string(t: String) -> String {

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -43,20 +43,24 @@ pub fn h1_3_test() {
 pub fn h1_4_test() {
   "<h1>Jello, Hoe!</h1>"
   |> html_lustre_converter.convert
-  |> should.equal("html.h1([], [text(\"Jello, Hoe!\")])")
+  |> should.equal("html.h1([], [html.text(\"Jello, Hoe!\")])")
 }
 
 pub fn text_test() {
   "Hello, Joe!"
   |> html_lustre_converter.convert
-  |> should.equal("text(\"Hello, Joe!\")")
+  |> should.equal("html.text(\"Hello, Joe!\")")
 }
 
 pub fn element_lustre_does_not_have_a_helper_for_test() {
   "<marquee>I will die mad that this element was removed</marquee>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "element(\"marquee\", [], [text(\"I will die mad that this element was removed\")])",
+    "element(
+  \"marquee\",
+  [],
+  [html.text(\"I will die mad that this element was removed\")],
+)",
   )
 }
 
@@ -64,7 +68,7 @@ pub fn attribute_test() {
   "<a href=\"https://gleam.run/\">The best site</a>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "html.a([attribute.href(\"https://gleam.run/\")], [text(\"The best site\")])",
+    "html.a([attribute.href(\"https://gleam.run/\")], [html.text(\"The best site\")])",
   )
 }
 
@@ -72,7 +76,7 @@ pub fn other_attribute_test() {
   "<a data-thing=\"1\">The best site</a>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "html.a([attribute(\"data-thing\", \"1\")], [text(\"The best site\")])",
+    "html.a([attribute(\"data-thing\", \"1\")], [html.text(\"The best site\")])",
   )
 }
 
@@ -98,7 +102,13 @@ pub fn its_already_a_page_test() {
   "<html><head><title>Hi</title></head><body>Yo</body></html>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "html.html(\n  [],\n  [html.head([], [html.title([], [text(\"Hi\")])]), html.body([], [text(\"Yo\")])],\n)",
+    "html.html(
+  [],
+  [
+    html.head([], [html.title([], [html.text(\"Hi\")])]),
+    html.body([], [html.text(\"Yo\")]),
+  ],
+)",
   )
 }
 
@@ -106,14 +116,14 @@ pub fn its_already_a_page_1_test() {
   "<html><head></head><body>Yo</body></html>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "html.html([], [html.head([], []), html.body([], [text(\"Yo\")])])",
+    "html.html([], [html.head([], []), html.body([], [html.text(\"Yo\")])])",
   )
 }
 
 pub fn text_with_a_quote_in_it_test() {
   "Here is a quote \" "
   |> html_lustre_converter.convert
-  |> should.equal("text(\"Here is a quote \\\" \")")
+  |> should.equal("html.text(\"Here is a quote \\\" \")")
 }
 
 pub fn non_string_attribute_test() {
@@ -154,8 +164,8 @@ pub fn full_page_test() {
     "html.html(
   [],
   [
-    html.head([], [html.title([], [text(\"Hello!\")])]),
-    html.body([], [html.h1([], [text(\"Goodbye!\")])]),
+    html.head([], [html.title([], [html.text(\"Hello!\")])]),
+    html.body([], [html.h1([], [html.text(\"Goodbye!\")])]),
   ],
 )",
   )
@@ -171,7 +181,7 @@ pub fn trailing_whitespace_test() {
   "<h1>Hello </h1><h2>world</h2>"
   |> html_lustre_converter.convert
   |> should.equal(
-    "[html.h1([], [text(\"Hello \")]), html.h2([], [text(\"world\")])]",
+    "[html.h1([], [html.text(\"Hello \")]), html.h2([], [html.text(\"world\")])]",
   )
 }
 
@@ -195,7 +205,11 @@ pub fn pre_whitespace_test() {
   |> should.equal(
     "html.pre(
   [],
-  [text(\"    \"), html.code([], [text(\"\n      Hello!\n    \")]), text(\"\n  \")],
+  [
+    html.text(\"    \"),
+    html.code([], [html.text(\"\n      Hello!\n    \")]),
+    html.text(\"\n  \"),
+  ],
 )",
   )
 }


### PR DESCRIPTION
The converter special cased some lustre functions (`text`, `attribute` and `element`) to not be qualified.
By always qualifying everything things are more regular and the LSP can suggest to import the relevant modules.