### PR TITLE
Fixed the generated code for the `style` element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the generated code for the `style` element.
+
 ## v1.3.0 - 2024-11-10
 
 - Fixed the generated code for `script`, `title` and `option` elements.

--- a/src/html_lustre_converter.gleam
+++ b/src/html_lustre_converter.gleam
@@ -288,7 +288,6 @@ fn print_element(
     | "small"
     | "span"
     | "strong"
-    | "style"
     | "sub"
     | "summary"
     | "sup"
@@ -328,7 +327,7 @@ fn print_element(
       |> doc.append(wrap([attributes, children], "(", ")"))
     }
 
-    "option" | "textarea" | "title" | "script" -> {
+    "script" | "style" | "textarea" | "title" | "option" -> {
       let content = doc.from_string(print_string(get_text_content(children)))
       doc.from_string("html." <> tag)
       |> doc.append(wrap([attributes, content], "(", ")"))

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -241,6 +241,12 @@ pub fn script_test() {
   |> should.equal("html.div([], [html.script([], \"const a = 1\")])")
 }
 
+pub fn style_test() {
+  "<div><style>body { padding: 5px }</style></div>"
+  |> html_lustre_converter.convert
+  |> should.equal("html.div([], [html.style([], \"body { padding: 5px }\")])")
+}
+
 pub fn title_test() {
   "<div><title>wibble wobble</title></div>"
   |> html_lustre_converter.convert


### PR DESCRIPTION
Same fix that was recently performed on `script`, `title` and `option`. With this, I searched the https://hexdocs.pm/lustre/lustre/element/html.html docs for others that may have `String` as the second parameter.

With this change and the others, all are now covered.

I also alphabetized the options for this case statement for easier maintenance.