### PR TITLE
Produce correct title tag inside of svg elements

### DIFF
--- a/src/html_lustre_converter.gleam
+++ b/src/html_lustre_converter.gleam
@@ -124,8 +124,7 @@ fn print_svg_element(
     | // Lighting elements
       "fedistantlight"
     | "fepointlight"
-    | "fespotlight"
-    | "title" -> {
+    | "fespotlight" -> {
       doc.from_string("svg." <> tag <> "(")
       |> doc.append(attributes)
       |> doc.append(doc.from_string(")"))
@@ -160,6 +159,7 @@ fn print_svg_element(
     | // Descriptive elements
       "desc"
     | "metadata"
+    | "title"
     | // Filter effects
       "fediffuselighting"
     | "femerge"

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -291,3 +291,12 @@ pub fn iframe_test() {
   |> html_lustre_converter.convert
   |> should.equal("html.iframe([])")
 }
+
+// Test because this finding:
+// https://github.com/lpil/html-lustre-converter/issues/26
+//
+pub fn title_inside_svg_test() {
+  "<svg><title>gleam</title></svg>"
+  |> html_lustre_converter.convert
+  |> should.equal("svg.svg([], [svg.title([], [html.text(\"gleam\")])])")
+}

--- a/test/html_lustre_converter_test.gleam
+++ b/test/html_lustre_converter_test.gleam
@@ -292,7 +292,7 @@ pub fn iframe_test() {
   |> should.equal("html.iframe([])")
 }
 
-// Test because this finding:
+// Test because of this finding:
 // https://github.com/lpil/html-lustre-converter/issues/26
 //
 pub fn title_inside_svg_test() {


### PR DESCRIPTION
Fixes https://github.com/lpil/html-lustre-converter/issues/26

I did this by pulling the "title" match inside the function into the branch of other descriptive elements which preserves the children.

I added a comment on the test to verify my changes linking the original issue. Not sure if this is wanted, I can remove that if you want it without any comments.